### PR TITLE
Compatibility with PHP5 < 5.4.0

### DIFF
--- a/AESCryptFileLib.php
+++ b/AESCryptFileLib.php
@@ -609,6 +609,11 @@ class AESCryptFileLib
 	
 	public static function bin_substr($string, $start, $length = NULL) {
 		if (function_exists('mb_substr')) {
+                        if (is_null($length)) {
+                                //Passing $length=NULL to mb_substring will treat it as 0
+                                //http://php.net/manual/en/function.mb-substr.php#77515
+                                $length = mb_strlen($string, '8bit');
+                        }
 			return mb_substr($string, $start, $length, '8bit');
 		} else {
 			return substr($string, $start, $length);

--- a/AESCryptFileLib.php
+++ b/AESCryptFileLib.php
@@ -544,7 +544,7 @@ class AESCryptFileLib
 	private function createKeyUsingIVAndPassphrase($iv, $passphrase) 
 	{
 		//Start with the IV padded to 32 bytes
-		$aes_key = str_pad($iv, 32, hex2bin("00"));
+		$aes_key = str_pad($iv, 32, self::hex2bin("00"));
 		$iterations = 8192;
 		for($i=0; $i<$iterations; $i++)
 		{
@@ -614,6 +614,22 @@ class AESCryptFileLib
 			return substr($string, $start, $length);
 		}
 	}
+        
+        //hex2bin wasn't introduced until PHP 5.4.0. If not present, use an alternative
+        //written by jannik: http://php.net/manual/en/function.hex2bin.php#113057
+        public static function hex2bin($string) {
+                if (function_exists('hex2bin')) {
+                        return hex2bin($string);
+                } else {
+                        $sbin = "";
+                        $len = strlen( $str );
+                        for ( $i = 0; $i < $len; $i += 2 ) {
+                                $sbin .= pack( "H*", substr( $str, $i, 2 ) );
+                        }
+
+                        return $sbin;
+                }
+        }
 	
 }
 

--- a/AESCryptFileLib.php
+++ b/AESCryptFileLib.php
@@ -627,9 +627,9 @@ class AESCryptFileLib
                         return hex2bin($string);
                 } else {
                         $sbin = "";
-                        $len = strlen( $str );
+                        $len = strlen( $string );
                         for ( $i = 0; $i < $len; $i += 2 ) {
-                                $sbin .= pack( "H*", substr( $str, $i, 2 ) );
+                                $sbin .= pack( "H*", substr( $string, $i, 2 ) );
                         }
 
                         return $sbin;


### PR DESCRIPTION
I noticed when testing PHP AES File Encryption in PHP 5.3.1 that the creation of key failed (because `hex2bin` wasn't introduced until PHP 5.4.0). In the readme of this project it states compatibility with PHP5 so I set out to fulfill that statement.

I have added a function similar to the `bin_*` functions in the library that checks if `hex2bin` exists, otherwise using an alternative approach with `pack` from the [PHP.net comment section](http://php.net/manual/en/function.hex2bin.php#113057).

Moreover, the `mb_substr` function seems to [treat length of NULL as zero](http://php.net/manual/en/function.mb-substr.php#77515). I have added a check for `NULL` length and replace it with the `mb_strlen` of the string.

Tested and working in PHP 5.3.1.
